### PR TITLE
fix: override any existing configuration during apt installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 recipes/build-info/files/.build_info
 **/debian-packages.list
 rugpi-bakery.toml
+*.log

--- a/recipes/mosquitto/steps/00-install.sh
+++ b/recipes/mosquitto/steps/00-install.sh
@@ -6,7 +6,7 @@
 echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian sid main' > /etc/apt/sources.list.d/debian-sid.list
 apt-get update
 
-DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install \
+DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Options::=--force-confnew -y --no-install-recommends install \
     mosquitto \
     mosquitto-clients
 

--- a/recipes/thin-edge.io/steps/00-install.sh
+++ b/recipes/thin-edge.io/steps/00-install.sh
@@ -4,7 +4,7 @@
 curl -fsSL https://thin-edge.io/install.sh | sh -s -- --channel main
 
 # Install collectd
-apt-get install -y --no-install-recommends \
+apt-get install -y -o DPkg::Options::=--force-confnew --no-install-recommends \
     mosquitto-clients \
     c8y-command-plugin \
     tedge-collectd-setup \


### PR DESCRIPTION
Fix build issue caused by dpkg failing to override an existing configuration file. Now the dpkg preference is set when installing apt packages to use the new configuration files by default.

This should make the builds more reliable.