### PR TITLE
refactor mosquitto state management

### DIFF
--- a/recipes/mosquitto/recipe.toml
+++ b/recipes/mosquitto/recipe.toml
@@ -1,1 +1,2 @@
 description = "install latest mosquitto version"
+priority = 200_000  # Execut before thin-edge.io

--- a/recipes/mosquitto/steps/00-install.sh
+++ b/recipes/mosquitto/steps/00-install.sh
@@ -6,7 +6,7 @@
 echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian sid main' > /etc/apt/sources.list.d/debian-sid.list
 apt-get update
 
-DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Options::=--force-confnew -y --no-install-recommends install \
+DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Options::=--force-confold -y --no-install-recommends install \
     mosquitto \
     mosquitto-clients
 

--- a/recipes/persist-data/files/data.toml
+++ b/recipes/persist-data/files/data.toml
@@ -1,5 +1,2 @@
 [[persist]]
 directory = "/data"
-
-[[persist]]
-directory = "/var/lib/mosquitto"

--- a/recipes/thin-edge.io/files/tedge-config.toml
+++ b/recipes/thin-edge.io/files/tedge-config.toml
@@ -4,5 +4,6 @@ directory = "/etc/tedge"
 [[persist]]
 directory = "/var/log/tedge"
 
+# mosquitto db file must be persisted
 [[persist]]
-directory = "/etc/mosquitto"
+directory = "/var/lib/mosquitto"


### PR DESCRIPTION
* move state management to thin-edge.io recipe
* don't persist mosquitto configuration (as the config should be controlled by the image)
* install latest mosquitto before install thin-edge.io to avoid accidentally overriding thin-edge.io config