### PR TITLE
feat: add timestamp to firmware version inventory script

### DIFF
--- a/recipes/tedge-firmware-update/files/firmware-version
+++ b/recipes/tedge-firmware-update/files/firmware-version
@@ -19,3 +19,8 @@ VERSION=$(rev /etc/.build_info | cut -d_ -f1 | rev)
 
 echo "name=\"$NAME\""
 echo "version=\"$VERSION\""
+
+# FIXME: Workaround since thin-edge.io does deduplication detection.
+# However this is only needed because the firmware/name is cleared on tedge-agent startup.
+# Remove once https://github.com/thin-edge/thin-edge.io/issues/2497 is resolved
+echo "updated=\"$(date)\""


### PR DESCRIPTION
Add workaround for the issue: https://github.com/thin-edge/thin-edge.io/issues/2497 